### PR TITLE
Avoid conflict with Salt user in exporter container

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ install_requires =
     Click
     rich
     requests
+    jinja2
 
 [options.packages.find]
 where=src

--- a/src/uyuni_health_check/exporter/Dockerfile
+++ b/src/uyuni_health_check/exporter/Dockerfile
@@ -10,6 +10,10 @@ COPY requirements.txt /opt/
 RUN zypper -n ref
 RUN zypper -n install python3-PyYAML python3-salt python3-pip postgresql
 RUN pip3.6 install -r /opt/requirements.txt
+# We remove the user salt (and group salt) to prevent conflicts in the shared volume
+# with the salt user that we will create later during container creation
+# according to the container host
+RUN userdel salt
 
 COPY uyuni_health_exporter.py /opt/
 COPY config.yml /opt/

--- a/src/uyuni_health_check/main.py
+++ b/src/uyuni_health_check/main.py
@@ -515,23 +515,35 @@ def run_loki(server, supportconfig_path=None, verbose=False):
         if server:
             transfer_image(server, "promtail")
 
-        podman(
+        podman_args = [
+            "run",
+            "--replace",
+            "-d",
+            "-v",
+            f"{promtail_cfg}:/etc/promtail/config.yml",
+            "-v",
+            "/var/log/:/var/log/",
+        ]
+
+        if supportconfig_path:
+            podman_args.extend(
+                [
+                    "-v",
+                    f"{supportconfig_path}:{supportconfig_path}",
+                ]
+            )
+
+        podman_args.extend(
             [
-                "run",
-                "--replace",
-                "-d",
-                "-v",
-                f"{promtail_cfg}:/etc/promtail/config.yml",
-                "-v",
-                "/var/log/:/var/log/",
-                "-v",
-                f"{supportconfig_path}:{supportconfig_path}",
                 "--name",
                 "promtail",
                 "--pod",
                 "uyuni-health-check",
                 "promtail",
-            ],
+            ]
+        )
+        podman(
+            podman_args,
             server,
             console=console,
         )


### PR DESCRIPTION
This PR does the following:

- Remove the user salt (and group salt) to prevent conflicts in the shared volume with the salt user that we will create later during container creation according to the container host.
- Fix `promtail` container not starting because of non-existent supportconfig path (if not passed as a command line argument).
- Add jinja2 as an installation requirement (otherwise the installation fails).
